### PR TITLE
Add AOP logging and Locale config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/helloworldenterprise/config/LocaleConfig.java
+++ b/src/main/java/com/example/helloworldenterprise/config/LocaleConfig.java
@@ -13,7 +13,7 @@ public class LocaleConfig {
     @Bean
     public LocaleResolver localeResolver() {
         AcceptHeaderLocaleResolver localeResolver = new AcceptHeaderLocaleResolver();
-        localeResolver.setDefaultLocale(Locale.ENGLISH);
+        localeResolver.setDefaultLocale(Locale.US);
         return localeResolver;
     }
 }

--- a/src/main/java/com/example/helloworldenterprise/util/RequestLoggingAspect.java
+++ b/src/main/java/com/example/helloworldenterprise/util/RequestLoggingAspect.java
@@ -1,0 +1,38 @@
+package com.example.helloworldenterprise.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Aspect that logs incoming requests to the {@code GreetingController}.
+ */
+@Component
+@Aspect
+public class RequestLoggingAspect {
+
+    private static final Logger logger = LoggerFactory.getLogger(RequestLoggingAspect.class);
+
+    @Pointcut("within(com.example.helloworldenterprise.presentation.controller.GreetingController)")
+    public void greetingControllerMethods() {
+        // Pointcut for GreetingController methods
+    }
+
+    @Before("greetingControllerMethods()")
+    public void logRequest() {
+        ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs != null) {
+            HttpServletRequest request = attrs.getRequest();
+            String method = request.getMethod();
+            String uri = request.getRequestURI();
+            String language = request.getHeader("Accept-Language");
+            logger.info("Incoming request {} {} Accept-Language={}", method, uri, language);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- configure LocaleResolver to use US locale
- enable request logging with a new aspect
- include Spring AOP starter dependency

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590a4ebfc8832fab8abf86759a5e5a