### PR TITLE
Add AOP dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary
- include `spring-boot-starter-aop` in Maven dependencies

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590a66e4c0832f9a352107f0722cf2