### PR TITLE
Fix incorrect exception message

### DIFF
--- a/src/main/java/com/example/helloworldenterprise/application/service/GreetingServiceImpl.java
+++ b/src/main/java/com/example/helloworldenterprise/application/service/GreetingServiceImpl.java
@@ -24,7 +24,7 @@ public class GreetingServiceImpl implements GreetingService {
     @Override
     public GreetingResponse getGreetingByLocale(Locale locale) {
         Greeting greeting = handler.handle(new GetGreetingQuery(locale))
-                .orElseThrow(() -> new GreetingNotFoundException("Greeting not found"));
+                .orElseThrow(() -> new GreetingNotFoundException(locale));
         return mapper.toDto(greeting);
     }
 


### PR DESCRIPTION
## Summary
- provide locale when throwing `GreetingNotFoundException`

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590cb1e620832f908be6afe75f43e7