### PR TITLE
Fix default locale in LocaleConfig

### DIFF
--- a/src/main/java/com/example/helloworldenterprise/config/LocaleConfig.java
+++ b/src/main/java/com/example/helloworldenterprise/config/LocaleConfig.java
@@ -13,7 +13,7 @@ public class LocaleConfig {
     @Bean
     public LocaleResolver localeResolver() {
         AcceptHeaderLocaleResolver localeResolver = new AcceptHeaderLocaleResolver();
-        localeResolver.setDefaultLocale(Locale.US);
+        localeResolver.setDefaultLocale(Locale.ENGLISH);
         return localeResolver;
     }
 }


### PR DESCRIPTION
## Summary
- avoid `GreetingNotFoundException` when no Accept-Language header is sent
- set the default locale to `Locale.ENGLISH` to match available greetings

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590cbafbf8832f83a9b398d59b93d3