### PR TITLE
Move greeting defaults to properties file

### DIFF
--- a/src/main/java/com/example/helloworldenterprise/infrastructure/repository/ConfigGreetingRepositoryImpl.java
+++ b/src/main/java/com/example/helloworldenterprise/infrastructure/repository/ConfigGreetingRepositoryImpl.java
@@ -23,9 +23,9 @@ public class ConfigGreetingRepositoryImpl implements GreetingRepository {
 
     public ConfigGreetingRepositoryImpl(
             GreetingFactory factory,
-            @Value("${greeting.english:Hello Config}") String english,
-            @Value("${greeting.french:Bonjour Config}") String french,
-            @Value("${greeting.german:Hallo Config}") String german) {
+            @Value("${greeting.english}") String english,
+            @Value("${greeting.french}") String french,
+            @Value("${greeting.german}") String german) {
         greetings.put(Locale.ENGLISH, factory.createGreeting(english));
         greetings.put(Locale.FRENCH, factory.createGreeting(french));
         greetings.put(Locale.GERMAN, factory.createGreeting(german));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 # Application configuration
+greeting.english=Hello Config
+greeting.french=Bonjour Config
+greeting.german=Hallo Config


### PR DESCRIPTION
## Summary
- externalize default greeting messages in `ConfigGreetingRepositoryImpl`
- define the greeting values in `application.properties`

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590cbfccf4832f85d8101e743b603f